### PR TITLE
Add TenEleven Group

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Feel free to submit pull requests or open issues to add any companies.
 | Stark & Wayne | Amherst | Cloud Infrastructure<br />Consulting | Cloud Foundry, AWS, Openstack, vSphere, some Go and postgres | beahero@starkandwayne.com |
 | StudioLabs | Buffalo | Agency Work | PHP, Javascript, some .NET | http://studiolabs.com/join |
 | Synacor | Buffalo | ISP Portals, Advertising & Identity Management | Primarily PHP, with Perl, Node, Go & Java | https://www.synacor.com/ |
+| TenEleven Group | East Amherst | Behavioral Health | C#, SQL Server  | https://www.10e11.com/careers |
 | Tesla | Buffalo | Manufacturing Execution Systems | C#, ASP.NET MVC, AngularJS  | https://www.tesla.com/careers |
 | Torch.io | Buffalo (DIG) | YCombinator backed Leadership coaching platform for high growth, high performance cultures  | Python, React/Redux, AWS, PostgreSQL, Serverless Framework | https://torch.io/careers |
 | Twisted Rope | Buffalo | Agency Work | Javascript, PHP | http://twisted-rope.com/ |


### PR DESCRIPTION
We spell our name "TenEleven Group" not "Ten Eleven Group."